### PR TITLE
xen/netfront: Request no checksum offload

### DIFF
--- a/xen/netfront.c
+++ b/xen/netfront.c
@@ -340,6 +340,11 @@ again:
         message = "writing event-channel";
         goto abort_transaction;
     }
+    err = xenbus_printf(xbt, nodename, "feature-no-csum-offload", "%u", 1);
+    if (err) {
+        message = "writing feature-no-csum-offload";
+        goto abort_transaction;
+    }
 
     err = xenbus_printf(xbt, nodename, "request-rx-copy", "%u", 1);
 


### PR DESCRIPTION
Checksum offload is not plumbed through to the networking stack, so
does not work.  Turn it off by writing the relevant key in xenstore.

It would be better, but more work, to plumb it through.

Signed-off-by: Ian Jackson Ian.Jackson@eu.citrix.com
