### PR TITLE
Fix non-working stunt ld with GCC 4.9 on Debian

### DIFF
--- a/app-tools/ld
+++ b/app-tools/ld
@@ -34,6 +34,11 @@ while [ $# != 0 ]; do
         	inter1="$1"; shift || noshift
         	inter2="$1"; shift || noshift
         	;;
+	-plugin|-plugin-opt)
+		shift || noshift
+		;;
+	-plugin-opt=*)
+		;;
 	*)
 		fail "unknown option $a"
 		;;


### PR DESCRIPTION
With (at least) GCC 4.9 on Debian jessie the GCC spec files have changed to always use -plugin / -plugin-opt and load the LTO plugin, even if -flto is not specified to GCC.

This breaks stunt ld which does not understand these options.

I can't find _any_ documentation whatsoever on when this was enabled, and whether or not -plugin is used for anything else besides LTO support. This may also be a distro and/or upstream bug?

In any case, dropping these options should do no harm and makes app-tools work with this GCC.
