### PR TITLE
rumpuser_exit(), _exit(): Cleanly halt Mini-OS.

### DIFF
--- a/include/mini-os/kernel.h
+++ b/include/mini-os/kernel.h
@@ -4,6 +4,11 @@
 extern int app_main(start_info_t *);
 
 extern void minios_do_exit(void) __attribute__((noreturn));
-extern void stop_kernel(void);
+extern void minios_stop_kernel(void);
+
+/* Values should mirror SHUTDOWN_* in xen/sched.h */
+#define MINIOS_HALT_POWEROFF 0
+#define MINIOS_HALT_CRASH 3
+extern void minios_do_halt(int reason) __attribute__((noreturn));
 
 #endif /* _MINIOS_KERNEL_H_ */

--- a/lib/emul.c
+++ b/lib/emul.c
@@ -77,6 +77,6 @@ munmap(void *addr, size_t len)
 void __dead
 _exit(int eval)
 {
-
-	minios_do_exit();
+	minios_stop_kernel();
+	minios_do_halt(MINIOS_HALT_POWEROFF);
 }

--- a/rumphyper_base.c
+++ b/rumphyper_base.c
@@ -216,8 +216,8 @@ rumpuser_getrandom(void *buf, size_t buflen, int flags, size_t *retp)
 void
 rumpuser_exit(int value)
 {
-
-	minios_do_exit();
+	minios_stop_kernel();
+	minios_do_halt(MINIOS_HALT_POWEROFF);
 }
 
 #define NBLKDEV 10

--- a/xen/kernel.c
+++ b/xen/kernel.c
@@ -137,7 +137,7 @@ void _minios_start_kernel(start_info_t *si)
     run_idle_thread();
 }
 
-void stop_kernel(void)
+void minios_stop_kernel(void)
 {
     /* TODO: fs import */
 
@@ -163,6 +163,22 @@ void stop_kernel(void)
 
     /* Reset arch details */
     arch_fini();
+}
+
+/*
+ * minios_do_halt: Called by "application" code to halt the Xen domain.
+ */
+
+void minios_do_halt(int reason)
+{
+    minios_printk("minios: halting, reason=%d\n", reason);
+    for( ;; )
+    {
+        struct sched_shutdown sched_shutdown = {
+            .reason = (reason == MINIOS_HALT_POWEROFF) ?
+                SHUTDOWN_poweroff : SHUTDOWN_crash };
+        HYPERVISOR_sched_op(SCHEDOP_shutdown, &sched_shutdown);
+    }
 }
 
 /*


### PR DESCRIPTION
rumpuser_exit() and _exit() were calling minios_do_exit() which is
intended to be called from an exception context and/or other "panic"
situation.  This was causing the stack trace code in minios_do_exit() to
walk off into never never land when the rumprun-xen application called
exit() or returned from main().

This commit adds a new minios_do_halt(reason) function, with the reason
code intended to mirror SHUTDOWN_\* in xen/sched.h. Of those, currently
only poweroff and crash are implemented.

We then modify the rumpuser_exit() and _exit() functions to correctly
shut down the domain by calling minios_stop_kernel() followed by
minios_do_halt(MINIOS_HALT_POWEROFF).

Signed-off-by: Martin Lucina martin@lucina.net
