### PR TITLE
Implement wall clock time (rumprun-xen issue #13)

### DIFF
--- a/rumphyper_synch.c
+++ b/rumphyper_synch.c
@@ -61,7 +61,7 @@ wait(struct waithead *wh, uint64_t nsec)
 	w.onlist = 1;
 	minios_block(w.who);
 	if (nsec)
-		w.who->wakeup_time = NOW() + nsec;
+		w.who->wakeup_time = minios_clock_monotonic() + nsec;
 	minios_schedule();
 
 	/* woken up by timeout? */

--- a/xen/include/mini-os/time.h
+++ b/xen/include/mini-os/time.h
@@ -30,7 +30,7 @@
  * of real time into system time 
  */
 typedef int64_t s_time_t;
-#define NOW()                   ((s_time_t)minios_monotonic_clock())
+#define NOW()                   ((s_time_t)minios_clock_monotonic())
 #define SECONDS(_s)             (((s_time_t)(_s))  * 1000000000UL )
 #define TENTHS(_ts)             (((s_time_t)(_ts)) * 100000000UL )
 #define HUNDREDTHS(_hs)         (((s_time_t)(_hs)) * 10000000UL )
@@ -50,7 +50,8 @@ void     init_time(void);
 void     fini_time(void);
 s_time_t get_s_time(void);
 s_time_t get_v_time(void);
-uint64_t minios_monotonic_clock(void);
+uint64_t minios_clock_monotonic(void);
+void     minios_clock_wall(uint32_t *sec, uint64_t *nsec);
 void     block_domain(s_time_t until);
 
 #endif /* _MINIOS_TIME_H_ */


### PR DESCRIPTION
Implement wall clock time, to fix issue #13.
The following test case produces the correct values for me, however:
- I'm not sure why I need the extra call to update_wallclock() on line 189 as this is already done in timer_handler() which I have confirmed is getting called.
- Changes to the dom0 clock (eg. resynch with ntpdate) don't seem to be reflected in the running domU clock. Not sure whether this is expected or not.

``` c
#include <stdio.h>
#include <time.h>
#include <unistd.h>

int main(int argc, char *argv[])
{
    int i;
    for (i = 0; i < 10; i++) {
        struct timespec ts_real, ts_monotonic;
        clock_gettime (CLOCK_REALTIME, &ts_real);
        clock_gettime (CLOCK_MONOTONIC, &ts_monotonic);
        struct tm tm_real;
        gmtime_r (&ts_real.tv_sec, &tm_real);
        char s_real [40];
        strftime (s_real, sizeof s_real, "%a, %d %b %Y %T", &tm_real);
        printf ("[%2ld.%ld] time is %s.%ld\n",
                ts_monotonic.tv_sec, ts_monotonic.tv_nsec,
                s_real, ts_real.tv_nsec);
        sleep (5);
    }
    return 0;
}
```

Example output:

```
=== calling main() ===

[ 1.10004999] time is Thu, 18 Dec 2014 15:15:44.511081917
[ 6.20004999] time is Thu, 18 Dec 2014 15:15:49.521081917
[11.30004999] time is Thu, 18 Dec 2014 15:15:54.531081917
[16.40004999] time is Thu, 18 Dec 2014 15:15:59.541081917
[21.50004999] time is Thu, 18 Dec 2014 15:16:04.551081917
[26.60004999] time is Thu, 18 Dec 2014 15:16:09.561081917
[31.70004999] time is Thu, 18 Dec 2014 15:16:14.571081917
[36.80004999] time is Thu, 18 Dec 2014 15:16:19.581081917
[41.90004999] time is Thu, 18 Dec 2014 15:16:24.591081917
[46.100004999] time is Thu, 18 Dec 2014 15:16:29.601081917

=== main() returned 0 ===
```
