### PR TITLE
xen: export more symbols

### DIFF
--- a/xen/Makefile
+++ b/xen/Makefile
@@ -44,7 +44,7 @@ LDFLAGS := -L$(abspath $(OBJ_DIR)/$(TARGET_ARCH_DIR))
 
 # Prefixes for global API names. All other symbols in mini-os are localised
 # before linking with rumprun applications.
-GLOBAL_PREFIXES := _minios_ minios_ HYPERVISOR_ blkfront_ netfront_ pcifront_ xenbus_
+GLOBAL_PREFIXES := _minios_ minios_ HYPERVISOR_ blkfront_ netfront_ pcifront_ xenbus_ gntmap_
 GLOBAL_PREFIXES := $(patsubst %,-G %*, $(GLOBAL_PREFIXES))
 
 # Subdirectories common to mini-os

--- a/xen/arch/x86/ioremap.c
+++ b/xen/arch/x86/ioremap.c
@@ -52,8 +52,8 @@ static void *__do_ioremap(unsigned long phys_addr, unsigned long size,
             goto mfn_invalid;
         }
     }   
-    va = (unsigned long)map_frames_ex(&mfns, num_pages, 0, 1, 1,
-                                      DOMID_IO, NULL, prot);
+    va = (unsigned long)minios_map_frames_ex(&mfns, num_pages, 0, 1, 1,
+                                             DOMID_IO, NULL, prot);
     return (void *)(va + offset);
     
 mfn_invalid:

--- a/xen/arch/x86/mm.c
+++ b/xen/arch/x86/mm.c
@@ -618,10 +618,10 @@ void do_map_frames(unsigned long va,
  * Map an array of MFNs contiguous into virtual address space. Virtual
  * addresses are allocated from the on demand area.
  */
-void *map_frames_ex(const unsigned long *mfns, unsigned long n, 
-                    unsigned long stride, unsigned long incr,
-                    unsigned long alignment,
-                    domid_t id, int *err, unsigned long prot)
+void *minios_map_frames_ex(const unsigned long *mfns, unsigned long n,
+                           unsigned long stride, unsigned long incr,
+                           unsigned long alignment,
+                           domid_t id, int *err, unsigned long prot)
 {
     unsigned long va = allocate_ondemand(n, alignment);
 

--- a/xen/include/mini-os/mm.h
+++ b/xen/include/mini-os/mm.h
@@ -65,7 +65,8 @@ void arch_init_p2m(unsigned long max_pfn_p);
 
 unsigned long allocate_ondemand(unsigned long n, unsigned long alignment);
 /* map f[i*stride]+i*increment for i in 0..n-1, aligned on alignment pages */
-void *map_frames_ex(const unsigned long *f, unsigned long n, unsigned long stride,
+void *minios_map_frames_ex(const unsigned long *f, unsigned long n,
+	unsigned long stride,
 	unsigned long increment, unsigned long alignment, domid_t id,
 	int *err, unsigned long prot);
 void do_map_frames(unsigned long addr,

--- a/xen/include/mini-os/x86/mm.h
+++ b/xen/include/mini-os/x86/mm.h
@@ -226,8 +226,8 @@ static __inline__ paddr_t machine_to_phys(maddr_t machine)
 })
 #define virtual_to_mfn(_virt)	   pte_to_mfn(virtual_to_pte(_virt))
 
-#define map_frames(f, n) map_frames_ex(f, n, 1, 0, 1, DOMID_SELF, NULL, L1_PROT)
-#define map_zero(n, a) map_frames_ex(&mfn_zero, n, 0, 0, a, DOMID_SELF, NULL, L1_PROT_RO)
+#define map_frames(f, n) minios_map_frames_ex(f, n, 1, 0, 1, DOMID_SELF, NULL, L1_PROT)
+#define map_zero(n, a) minios_map_frames_ex(&mfn_zero, n, 0, 0, a, DOMID_SELF, NULL, L1_PROT_RO)
 #define do_map_zero(start, n) do_map_frames(start, &mfn_zero, n, 0, 0, DOMID_SELF, NULL, L1_PROT_RO)
 
 pgentry_t *need_pgt(unsigned long addr);


### PR DESCRIPTION
I discovered that we need gntmap_\* symbols and map_frames_ex when trying
to build libxenctrl against rump kernel.

Admittedly exporting map_frames_ex is not pretty but it's a good enough
workaround until we clean up mini-os name space.

Signed-off-by: Wei Liu liuw@liuw.name
